### PR TITLE
feat: bootstrap installable repo-hc package (AGENTS canonical)

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -31,16 +31,19 @@ This folder stores reusable agent knowledge for consistent, safe, and fast colla
 ### Plans
 
 - [2026-03-11-github-housekeeping-doc-refresh.md](./plans/2026-03-11-github-housekeeping-doc-refresh.md)
+- [2026-03-11-publishable-repo-hc-package-bootstrap.md](./plans/2026-03-11-publishable-repo-hc-package-bootstrap.md)
 - [examples/2026-03-11-add-docs-workflow-guides.md](./plans/examples/2026-03-11-add-docs-workflow-guides.md)
 - [examples/2026-03-11-central-api-docs-mermaid.md](./plans/examples/2026-03-11-central-api-docs-mermaid.md)
 
 ### Learnings
 
+- [03_repo-hc-install-bootstrap.md](./learnings/03_repo-hc-install-bootstrap.md)
 - [examples/01_workspace-peer-dependency-resolution.md](./learnings/examples/01_workspace-peer-dependency-resolution.md)
 - [examples/02_shared-drizzle-workspace-package.md](./learnings/examples/02_shared-drizzle-workspace-package.md)
 
 ### Prompts
 
+- [03_repo-hc-install-bootstrap.md](./prompts/03_repo-hc-install-bootstrap.md)
 - [examples/01_workspace-peer-dependency-resolution.md](./prompts/examples/01_workspace-peer-dependency-resolution.md)
 - [examples/02_shared-drizzle-workspace-package.md](./prompts/examples/02_shared-drizzle-workspace-package.md)
 

--- a/.agents/learnings/03_repo-hc-install-bootstrap.md
+++ b/.agents/learnings/03_repo-hc-install-bootstrap.md
@@ -1,0 +1,41 @@
+# Learning: repo-hc Install Bootstrap to Project Root
+
+## Links
+- README: `../README.md`
+- Prompt: `../prompts/03_repo-hc-install-bootstrap.md`
+- Plan: `../plans/2026-03-11-publishable-repo-hc-package-bootstrap.md`
+
+## Context
+The package needed to support one-step installation with:
+
+```bash
+pnpm add repo-hc
+```
+
+while ensuring these assets appear in consumer project roots:
+
+- `.agents/`
+- `docs/`
+- `AGENTS.md` (canonical)
+- `AGENT.md` (compatibility alias)
+
+## Decision
+- Use `postinstall` to run an internal bootstrap command (`repo-hc install`).
+- Implement a non-destructive copy strategy:
+  - copy missing files/directories
+  - preserve existing files by default
+  - allow explicit overwrite via `repo-hc init --force`
+
+## Implementation Structure
+- `bin/repo-hc.cjs`: CLI command dispatch (`init`, `install`)
+- `lib/bootstrap.cjs`: reusable recursive copy logic
+- `package.json`: `bin`, `files`, `postinstall`, and test script
+
+## Guardrails
+- `install` never breaks package installation if bootstrap fails.
+- `REPO_HC_SKIP_POSTINSTALL=1` allows skipping bootstrap in CI or controlled setups.
+- Global installs are ignored by bootstrap to avoid writing outside intended project roots.
+
+## Validation
+- Added `node:test` coverage for copy and force-overwrite behavior.
+- Updated docs to describe install behavior and manual re-run commands.

--- a/.agents/plans/2026-03-11-publishable-repo-hc-package-bootstrap.md
+++ b/.agents/plans/2026-03-11-publishable-repo-hc-package-bootstrap.md
@@ -1,0 +1,28 @@
+﻿# Plan: Publishable repo-hc Package Bootstrap
+
+## Date
+- 2026-03-11
+
+## Goal
+Enable consumers to run `pnpm add repo-hc` (without `-D`) and receive the following assets in their project root:
+- `.agents/`
+- `docs/`
+- `AGENTS.md` (canonical)
+- `AGENT.md` (compatibility alias)
+
+## Scope
+1. Add a publishable npm package scaffold (`package.json`, CLI entrypoint, install hook).
+2. Implement non-destructive root bootstrap logic for copying package assets into `INIT_CWD`.
+3. Provide a manual command (`repo-hc init`) for re-running bootstrap.
+4. Add tests for bootstrap copy behavior.
+5. Update documentation to reflect installation and bootstrap behavior.
+
+## Non-Goals
+- Implementing full AI workflow runtime logic.
+- Publishing to npm in this change.
+
+## Validation
+- Run tests for copy behavior.
+- Dry-run local CLI init into a temporary folder.
+- Verify docs mention `pnpm add repo-hc` and expected copied assets.
+

--- a/.agents/prompts/03_repo-hc-install-bootstrap.md
+++ b/.agents/prompts/03_repo-hc-install-bootstrap.md
@@ -1,0 +1,17 @@
+# Prompt: repo-hc One-Step Install Bootstrap
+
+## Links
+- README: `../README.md`
+- Learning: `../learnings/03_repo-hc-install-bootstrap.md`
+- Plan: `../plans/2026-03-11-publishable-repo-hc-package-bootstrap.md`
+
+## Original Prompt (Sanitized)
+```text
+What is required so users can run "pnpm add repo-hc" and automatically receive:
+- .agents
+- docs
+- AGENTS.md (canonical)
+- AGENT.md (compatibility alias)
+
+Implement it without using -D.
+```

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - [Vision](#vision)
 - [AI Agent Workflow System](#ai-agent-workflow-system)
 - [Planned Installation (When Published)](#planned-installation-when-published)
+- [Bootstrap Behavior](#bootstrap-behavior)
 - [What The Package Will Cover](#what-the-package-will-cover)
 - [Documentation System](#documentation-system)
 - [Repository Layout](#repository-layout)
@@ -56,7 +57,7 @@ AI-assisted work in this repository is guided by [AGENTS.md](./AGENTS.md) and th
 ## Planned Installation (When Published)
 
 ```bash
-<package-manager> add -D repo-hc
+pnpm add repo-hc
 ```
 
 The package name is `repo-hc`. Until publish time, this repository is the source of truth for the workflow model and documentation.
@@ -64,6 +65,27 @@ The package name is `repo-hc`. Until publish time, this repository is the source
 > [!TIP]
 > Start every AI-assisted task with [AGENTS.md](./AGENTS.md), then continue with [`.agents/README.md`](./.agents/README.md), then [docs/README.md](./docs/README.md).
 > The effective behavior rules are user-defined in [`/.agents/rules`](./.agents/rules/).
+
+## Bootstrap Behavior
+
+After `pnpm add repo-hc`, the package `postinstall` bootstraps these assets into the consumer project root:
+
+- `.agents/`
+- `docs/`
+- `AGENTS.md` (canonical)
+- `AGENT.md` (compatibility alias generated from `AGENTS.md`)
+
+Existing files are preserved by default (non-destructive copy). To re-run manually:
+
+```bash
+pnpm exec repo-hc init
+```
+
+To overwrite existing files intentionally:
+
+```bash
+pnpm exec repo-hc init --force
+```
 
 ## What The Package Will Cover
 

--- a/bin/repo-hc.cjs
+++ b/bin/repo-hc.cjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+const path = require("node:path");
+const { bootstrapProjectRoot, BOOTSTRAP_ITEMS } = require("../lib/bootstrap.cjs");
+
+function printHelp() {
+  console.log("repo-hc");
+  console.log("");
+  console.log("Usage:");
+  console.log("  repo-hc init [--force] [--target <path>]");
+  console.log("  repo-hc install");
+  console.log("");
+  console.log("Commands:");
+  console.log("  init     Copy .agents, docs, AGENTS.md and compatibility AGENT.md into a project root.");
+  console.log("  install  Internal command used by postinstall.");
+  console.log("");
+  console.log("Flags:");
+  console.log("  --force        Overwrite existing files.");
+  console.log("  --target PATH  Target project root (default: current directory).");
+}
+
+function parseOptionValue(args, optionName) {
+  const optionIndex = args.indexOf(optionName);
+  if (optionIndex < 0 || optionIndex + 1 >= args.length) {
+    return null;
+  }
+
+  return args[optionIndex + 1];
+}
+
+function runBootstrap({ targetRoot, force, silent }) {
+  const packageRoot = path.resolve(__dirname, "..");
+  const summary = bootstrapProjectRoot({
+    sourceRoot: packageRoot,
+    targetRoot,
+    force,
+  });
+
+  if (silent) {
+    return summary;
+  }
+
+  console.log("[repo-hc] Bootstrap completed.");
+  console.log(`[repo-hc] Target: ${path.resolve(targetRoot)}`);
+  console.log(`[repo-hc] Items: ${BOOTSTRAP_ITEMS.join(", ")} + AGENT.md compatibility alias`);
+  console.log(`[repo-hc] Copied files: ${summary.copiedFiles}`);
+  console.log(`[repo-hc] Skipped existing files: ${summary.skippedFiles}`);
+  console.log(`[repo-hc] Created directories: ${summary.createdDirectories}`);
+  if (summary.missingSources.length > 0) {
+    console.warn(`[repo-hc] Missing package sources: ${summary.missingSources.join(", ")}`);
+  }
+
+  return summary;
+}
+
+function runInitCommand(args) {
+  const force = args.includes("--force");
+  const targetOption = parseOptionValue(args, "--target");
+  const targetRoot = targetOption ? path.resolve(targetOption) : process.cwd();
+  runBootstrap({ targetRoot, force, silent: false });
+}
+
+function runInstallCommand() {
+  if (process.env.REPO_HC_SKIP_POSTINSTALL === "1") {
+    return;
+  }
+
+  if (process.env.npm_config_global === "true") {
+    return;
+  }
+
+  const targetRoot = process.env.INIT_CWD
+    ? path.resolve(process.env.INIT_CWD)
+    : process.cwd();
+
+  try {
+    runBootstrap({ targetRoot, force: false, silent: true });
+  } catch (error) {
+    // Never break installation if bootstrap fails during postinstall.
+    const message = error && error.message ? error.message : String(error);
+    console.warn(`[repo-hc] postinstall bootstrap skipped: ${message}`);
+  }
+}
+
+function main() {
+  const [, , command, ...args] = process.argv;
+
+  if (!command || command === "--help" || command === "-h") {
+    printHelp();
+    return;
+  }
+
+  if (command === "init") {
+    runInitCommand(args);
+    return;
+  }
+
+  if (command === "install") {
+    runInstallCommand();
+    return;
+  }
+
+  console.error(`[repo-hc] Unknown command: ${command}`);
+  printHelp();
+  process.exitCode = 1;
+}
+
+main();

--- a/docs/housekeeping/README.md
+++ b/docs/housekeeping/README.md
@@ -2,6 +2,15 @@
 
 This section documents the planned `repo-hc` npm package for automated GitHub housekeeping with AI-agent guidance.
 
+Core install behavior:
+
+```bash
+pnpm add repo-hc
+```
+
+This bootstraps `.agents/`, `docs/`, and `AGENTS.md` into the project root.
+`AGENT.md` is generated as a compatibility alias from `AGENTS.md`.
+
 ## Documents
 
 - [Developer Guide](./developers.md)

--- a/docs/housekeeping/developers.md
+++ b/docs/housekeeping/developers.md
@@ -26,6 +26,24 @@ Current status: architecture and documentation baseline, package runtime not pub
 - `types/`: shared public and internal contracts
 - `config/`: environment parsing and defaults
 
+## Package Bootstrap Runtime
+
+`repo-hc` ships with a CLI and an install hook:
+
+- `bin/repo-hc.cjs`: CLI entrypoint (`init`, `install`)
+- `lib/bootstrap.cjs`: non-destructive copy logic
+- `package.json` `postinstall`: runs `repo-hc install`
+
+Default install behavior copies these package assets to consumer root:
+
+- `.agents/`
+- `docs/`
+- `AGENTS.md`
+- `AGENT.md` (generated as compatibility alias from `AGENTS.md`)
+
+`install` is intentionally non-destructive and does not overwrite existing files.
+Use `repo-hc init --force` for explicit overwrite.
+
 ## Security Requirements
 
 - Never embed real tokens, secrets, or private repository data in source or docs.
@@ -59,6 +77,7 @@ At minimum, validate:
 - architecture docs reflect current structure
 - security guidance is still enforced
 - rule references in `.agents` remain accurate
+- bootstrap tests pass (`node --test ./test/*.test.cjs`)
 
 ## Related
 

--- a/docs/housekeeping/users.md
+++ b/docs/housekeeping/users.md
@@ -21,10 +21,21 @@ Primary target: OpenAI Codex workflows.
 After publication, usage is expected to look like:
 
 ```bash
-<package-manager> add -D <package-name>
+pnpm add repo-hc
 ```
 
-The package name is not finalized yet.
+During installation, `repo-hc` bootstraps the following assets into the project root:
+
+- `.agents/`
+- `docs/`
+- `AGENTS.md` (canonical)
+- `AGENT.md` (compatibility alias)
+
+Manual re-run:
+
+```bash
+pnpm exec repo-hc init
+```
 
 ## Typical Workflow
 

--- a/docs/mermaid/housekeeping-architecture.md
+++ b/docs/mermaid/housekeeping-architecture.md
@@ -33,3 +33,16 @@ flowchart TD
 
   PERM -->|deny| BLOCK["Blocked Operation"]
 ```
+
+## Install Bootstrap Flow
+
+```mermaid
+flowchart LR
+  ADD["pnpm add repo-hc"] --> POSTINSTALL["postinstall: repo-hc install"]
+  POSTINSTALL --> COPY["Bootstrap Copy"]
+  COPY --> AGENTS[".agents/"]
+  COPY --> DOCS["docs/"]
+  COPY --> AGENTSFILE["AGENTS.md (canonical)"]
+  COPY --> AGENT["AGENT.md (alias)"]
+  COPY --> SAFE["Non-destructive by default"]
+```

--- a/lib/bootstrap.cjs
+++ b/lib/bootstrap.cjs
@@ -1,0 +1,103 @@
+﻿const fs = require("node:fs");
+const path = require("node:path");
+
+const BOOTSTRAP_ITEMS = [".agents", "docs", "AGENTS.md"];
+const BOOTSTRAP_ALIASES = [{ source: "AGENTS.md", target: "AGENT.md" }];
+
+function ensureDirectory(dirPath, summary) {
+  if (fs.existsSync(dirPath)) {
+    return;
+  }
+
+  fs.mkdirSync(dirPath, { recursive: true });
+  summary.createdDirectories += 1;
+}
+
+function copyFileSafe(sourceFile, targetFile, force, summary) {
+  const fileExists = fs.existsSync(targetFile);
+  if (fileExists && !force) {
+    summary.skippedFiles += 1;
+    return;
+  }
+
+  fs.copyFileSync(sourceFile, targetFile);
+  summary.copiedFiles += 1;
+}
+
+function copyDirectorySafe(sourceDir, targetDir, force, summary) {
+  ensureDirectory(targetDir, summary);
+
+  const directoryEntries = fs.readdirSync(sourceDir, { withFileTypes: true });
+  for (const entry of directoryEntries) {
+    const sourceEntry = path.join(sourceDir, entry.name);
+    const targetEntry = path.join(targetDir, entry.name);
+
+    if (entry.isDirectory()) {
+      copyDirectorySafe(sourceEntry, targetEntry, force, summary);
+      continue;
+    }
+
+    if (entry.isFile()) {
+      copyFileSafe(sourceEntry, targetEntry, force, summary);
+    }
+  }
+}
+
+function bootstrapProjectRoot({
+  sourceRoot,
+  targetRoot,
+  force = false,
+}) {
+  const absoluteSourceRoot = path.resolve(sourceRoot);
+  const absoluteTargetRoot = path.resolve(targetRoot);
+  const summary = {
+    copiedFiles: 0,
+    skippedFiles: 0,
+    createdDirectories: 0,
+    missingSources: [],
+  };
+
+  if (absoluteSourceRoot === absoluteTargetRoot) {
+    return summary;
+  }
+
+  for (const item of BOOTSTRAP_ITEMS) {
+    const sourcePath = path.join(absoluteSourceRoot, item);
+    const targetPath = path.join(absoluteTargetRoot, item);
+
+    if (!fs.existsSync(sourcePath)) {
+      summary.missingSources.push(item);
+      continue;
+    }
+
+    const stats = fs.statSync(sourcePath);
+    if (stats.isDirectory()) {
+      copyDirectorySafe(sourcePath, targetPath, force, summary);
+      continue;
+    }
+
+    ensureDirectory(path.dirname(targetPath), summary);
+    copyFileSafe(sourcePath, targetPath, force, summary);
+  }
+
+  for (const alias of BOOTSTRAP_ALIASES) {
+    const sourcePath = path.join(absoluteSourceRoot, alias.source);
+    const targetPath = path.join(absoluteTargetRoot, alias.target);
+
+    if (!fs.existsSync(sourcePath)) {
+      summary.missingSources.push(alias.source);
+      continue;
+    }
+
+    ensureDirectory(path.dirname(targetPath), summary);
+    copyFileSafe(sourcePath, targetPath, force, summary);
+  }
+
+  return summary;
+}
+
+module.exports = {
+  BOOTSTRAP_ALIASES,
+  BOOTSTRAP_ITEMS,
+  bootstrapProjectRoot,
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,40 @@
+﻿{
+  "name": "repo-hc",
+  "version": "0.1.0",
+  "description": "Bootstrap AI-agent housekeeping docs and rules into repository roots.",
+  "license": "AGPL-3.0",
+  "type": "commonjs",
+  "bin": {
+    "repo-hc": "bin/repo-hc.cjs"
+  },
+  "files": [
+    "bin/",
+    "lib/",
+    "docs/",
+    ".agents/",
+    "AGENTS.md",
+    "README.md",
+    "LICENSE.txt",
+    "SECURITY.md",
+    "CONTRIBUTING.md"
+  ],
+  "scripts": {
+    "postinstall": "node ./bin/repo-hc.cjs install",
+    "test": "node --test ./test/*.test.cjs"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/iptoux/repo-hc.git"
+  },
+  "keywords": [
+    "ai-agent",
+    "housekeeping",
+    "github",
+    "documentation",
+    "bootstrap"
+  ]
+}
+

--- a/test/bootstrap.test.cjs
+++ b/test/bootstrap.test.cjs
@@ -1,0 +1,62 @@
+﻿const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const { bootstrapProjectRoot } = require("../lib/bootstrap.cjs");
+
+function writeFile(filePath, content) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf8");
+}
+
+test("bootstrap copies required assets into target root", () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "repo-hc-bootstrap-"));
+  const sourceRoot = path.join(workspace, "source");
+  const targetRoot = path.join(workspace, "target");
+
+  writeFile(path.join(sourceRoot, ".agents", "rules", "01_rule.md"), "rule");
+  writeFile(path.join(sourceRoot, "docs", "README.md"), "docs");
+  writeFile(path.join(sourceRoot, "AGENTS.md"), "agents");
+  fs.mkdirSync(targetRoot, { recursive: true });
+
+  const summary = bootstrapProjectRoot({ sourceRoot, targetRoot, force: false });
+  assert.equal(summary.copiedFiles, 4);
+  assert.equal(summary.skippedFiles, 0);
+  assert.equal(summary.missingSources.length, 0);
+
+  assert.equal(fs.readFileSync(path.join(targetRoot, "AGENTS.md"), "utf8"), "agents");
+  assert.equal(fs.readFileSync(path.join(targetRoot, "AGENT.md"), "utf8"), "agents");
+  assert.equal(
+    fs.readFileSync(path.join(targetRoot, ".agents", "rules", "01_rule.md"), "utf8"),
+    "rule",
+  );
+  assert.equal(fs.readFileSync(path.join(targetRoot, "docs", "README.md"), "utf8"), "docs");
+});
+
+test("bootstrap skips existing files unless force is enabled", () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "repo-hc-bootstrap-"));
+  const sourceRoot = path.join(workspace, "source");
+  const targetRoot = path.join(workspace, "target");
+
+  writeFile(path.join(sourceRoot, "AGENTS.md"), "new-content");
+  writeFile(path.join(sourceRoot, ".agents", "rules", "01_rule.md"), "new-rule");
+  writeFile(path.join(sourceRoot, "docs", "README.md"), "new-docs");
+
+  writeFile(path.join(targetRoot, "AGENTS.md"), "existing-content");
+  writeFile(path.join(targetRoot, "AGENT.md"), "existing-content");
+  writeFile(path.join(targetRoot, ".agents", "rules", "01_rule.md"), "existing-rule");
+  writeFile(path.join(targetRoot, "docs", "README.md"), "existing-docs");
+
+  const skippedSummary = bootstrapProjectRoot({ sourceRoot, targetRoot, force: false });
+  assert.equal(skippedSummary.copiedFiles, 0);
+  assert.equal(skippedSummary.skippedFiles, 4);
+  assert.equal(fs.readFileSync(path.join(targetRoot, "AGENTS.md"), "utf8"), "existing-content");
+  assert.equal(fs.readFileSync(path.join(targetRoot, "AGENT.md"), "utf8"), "existing-content");
+
+  const forcedSummary = bootstrapProjectRoot({ sourceRoot, targetRoot, force: true });
+  assert.equal(forcedSummary.copiedFiles, 4);
+  assert.equal(fs.readFileSync(path.join(targetRoot, "AGENTS.md"), "utf8"), "new-content");
+  assert.equal(fs.readFileSync(path.join(targetRoot, "AGENT.md"), "utf8"), "new-content");
+});


### PR DESCRIPTION
## Summary
- add a publishable `repo-hc` npm package scaffold (`package.json`, bin CLI, lib bootstrap)
- implement install/bootstrap behavior for `pnpm add repo-hc` to copy `.agents`, `docs`, and `AGENTS.md`
- keep `AGENTS.md` as canonical and generate `AGENT.md` as compatibility alias
- add tests for non-destructive copy and `--force` overwrite behavior
- update docs and Mermaid architecture to reflect the new install/bootstrap flow

## Validation
- `node --test ./test/*.test.cjs`
- simulated install bootstrap via `INIT_CWD`
- `npm pack --dry-run` to verify packaged assets