### PR TITLE
feat: switch repo-hc bootstrap to init-first flow (no postinstall)

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -35,6 +35,7 @@ This folder stores reusable agent knowledge for consistent, safe, and fast colla
 - [2026-03-12-remove-legacy-alias-references.md](./plans/2026-03-12-remove-legacy-alias-references.md)
 - [2026-03-12-postinstall-vscode-hide-agent-files.md](./plans/2026-03-12-postinstall-vscode-hide-agent-files.md)
 - [2026-03-12-bootstrap-transfer-examples-only.md](./plans/2026-03-12-bootstrap-transfer-examples-only.md)
+- [2026-03-12-switch-to-init-first-bootstrap.md](./plans/2026-03-12-switch-to-init-first-bootstrap.md)
 - [examples/2026-03-11-add-docs-workflow-guides.md](./plans/examples/2026-03-11-add-docs-workflow-guides.md)
 - [examples/2026-03-11-central-api-docs-mermaid.md](./plans/examples/2026-03-11-central-api-docs-mermaid.md)
 
@@ -43,6 +44,7 @@ This folder stores reusable agent knowledge for consistent, safe, and fast colla
 - [03_repo-hc-install-bootstrap.md](./learnings/03_repo-hc-install-bootstrap.md)
 - [04_postinstall-vscode-hide-agent-files.md](./learnings/04_postinstall-vscode-hide-agent-files.md)
 - [05_bootstrap-transfer-examples-only.md](./learnings/05_bootstrap-transfer-examples-only.md)
+- [06_init-first-bootstrap-flow.md](./learnings/06_init-first-bootstrap-flow.md)
 - [examples/01_workspace-peer-dependency-resolution.md](./learnings/examples/01_workspace-peer-dependency-resolution.md)
 - [examples/02_shared-drizzle-workspace-package.md](./learnings/examples/02_shared-drizzle-workspace-package.md)
 
@@ -51,6 +53,7 @@ This folder stores reusable agent knowledge for consistent, safe, and fast colla
 - [03_repo-hc-install-bootstrap.md](./prompts/03_repo-hc-install-bootstrap.md)
 - [04_postinstall-vscode-hide-agent-files.md](./prompts/04_postinstall-vscode-hide-agent-files.md)
 - [05_bootstrap-transfer-examples-only.md](./prompts/05_bootstrap-transfer-examples-only.md)
+- [06_init-first-bootstrap-flow.md](./prompts/06_init-first-bootstrap-flow.md)
 - [examples/01_workspace-peer-dependency-resolution.md](./prompts/examples/01_workspace-peer-dependency-resolution.md)
 - [examples/02_shared-drizzle-workspace-package.md](./prompts/examples/02_shared-drizzle-workspace-package.md)
 

--- a/.agents/learnings/06_init-first-bootstrap-flow.md
+++ b/.agents/learnings/06_init-first-bootstrap-flow.md
@@ -1,0 +1,23 @@
+# Learning: Init-First Bootstrap Flow
+
+## Links
+- README: `../README.md`
+- Prompt: `../prompts/06_init-first-bootstrap-flow.md`
+- Plan: `../plans/2026-03-12-switch-to-init-first-bootstrap.md`
+
+## Context
+`postinstall` required pnpm build-script approval in many setups and reduced install UX predictability.
+
+## Decision
+- Use `repo-hc init` as the explicit bootstrap entrypoint after package installation.
+- Remove `postinstall` script wiring from `package.json`.
+- Keep VS Code hide prompt behavior, but run it from `init`.
+- Keep bootstrap copy behavior non-destructive and unchanged.
+
+## Implementation Structure
+- `package.json`: remove `postinstall`
+- `bin/repo-hc.cjs`: remove `install` command and run VS Code prompt in `init`
+- `docs/*`: update usage, workflow, and Mermaid flow to init-first
+
+## Validation
+- `node --test ./test/*.test.cjs`

--- a/.agents/plans/2026-03-12-switch-to-init-first-bootstrap.md
+++ b/.agents/plans/2026-03-12-switch-to-init-first-bootstrap.md
@@ -1,0 +1,22 @@
+# Plan: Switch to Init-First Bootstrap Flow
+
+## Date
+- 2026-03-12
+
+## Goal
+Use `repo-hc init` as the primary bootstrap action instead of `postinstall`, and keep the VS Code hide prompt in the `init` flow.
+
+## Scope
+1. Remove package `postinstall` script wiring.
+2. Remove `install` command flow from CLI and move VS Code hide prompt handling into `init`.
+3. Update docs (`README`, housekeeping docs, Mermaid) to describe init-first usage.
+4. Update `.agents` learnings/prompts to avoid stale postinstall guidance.
+5. Keep current bootstrap copy behavior (including examples-only filtering) unchanged.
+
+## Non-Goals
+- Changing copied asset set.
+- Introducing additional commands or environment variables.
+
+## Validation
+- Run `node --test ./test/*.test.cjs`.
+- Verify docs no longer describe postinstall as default bootstrap mechanism.

--- a/.agents/prompts/06_init-first-bootstrap-flow.md
+++ b/.agents/prompts/06_init-first-bootstrap-flow.md
@@ -1,0 +1,11 @@
+# Prompt: Switch to Init-First Bootstrap
+
+## Links
+- README: `../README.md`
+- Learning: `../learnings/06_init-first-bootstrap-flow.md`
+- Plan: `../plans/2026-03-12-switch-to-init-first-bootstrap.md`
+
+## Original Prompt (Sanitized)
+```text
+okay, then switch to init command please and update the readme and needed docs. vscode agents file hide should also come with init.
+```

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ AI-assisted work in this repository is guided by [AGENTS.md](./AGENTS.md) and th
 ```bash
 npm view repo-hc version
 pnpm add repo-hc
+pnpm exec repo-hc init
 ```
 
 Install directly from npm:
@@ -74,7 +75,7 @@ Install directly from npm:
 
 ## Bootstrap Behavior
 
-After `pnpm add repo-hc`, the package `postinstall` bootstraps these assets into the consumer project root:
+Run `repo-hc init` after installation to bootstrap these assets into the consumer project root:
 
 - `.agents/`
 - `docs/`
@@ -89,13 +90,13 @@ For `.agents/`, repository-internal non-example files are excluded from transfer
 
 Only each folder's `examples/` content is copied for those areas.
 
-When installation runs interactively, `repo-hc` also asks whether common agent files should be hidden in VS Code Explorer.  
+When `repo-hc init` runs interactively, it also asks whether common agent files should be hidden in VS Code Explorer.  
 If confirmed, it creates or updates `.vscode/settings.json` with `files.exclude` entries for:
 
 - `.agents`
 - `AGENTS.md`
 
-Existing files are preserved by default (non-destructive copy). To re-run manually:
+Existing files are preserved by default (non-destructive copy). To run or re-run:
 
 ```bash
 pnpm exec repo-hc init

--- a/bin/repo-hc.cjs
+++ b/bin/repo-hc.cjs
@@ -9,11 +9,9 @@ function printHelp() {
   console.log("");
   console.log("Usage:");
   console.log("  repo-hc init [--force] [--target <path>]");
-  console.log("  repo-hc install");
   console.log("");
   console.log("Commands:");
   console.log("  init     Copy .agents, docs, and AGENTS.md into a project root.");
-  console.log("  install  Internal command used by postinstall.");
   console.log("");
   console.log("Flags:");
   console.log("  --force        Overwrite existing files.");
@@ -54,29 +52,13 @@ function runBootstrap({ targetRoot, force, silent }) {
   return summary;
 }
 
-function runInitCommand(args) {
+async function runInitCommand(args) {
   const force = args.includes("--force");
   const targetOption = parseOptionValue(args, "--target");
   const targetRoot = targetOption ? path.resolve(targetOption) : process.cwd();
   runBootstrap({ targetRoot, force, silent: false });
-}
-
-async function runInstallCommand() {
-  if (process.env.REPO_HC_SKIP_POSTINSTALL === "1") {
-    return;
-  }
-
-  if (process.env.npm_config_global === "true") {
-    return;
-  }
-
-  const targetRoot = process.env.INIT_CWD
-    ? path.resolve(process.env.INIT_CWD)
-    : process.cwd();
 
   try {
-    runBootstrap({ targetRoot, force: false, silent: true });
-
     const vscodeResult = await maybeConfigureAgentFilesExclude({ targetRoot });
     if (vscodeResult.status === "updated") {
       console.log(
@@ -84,9 +66,8 @@ async function runInstallCommand() {
       );
     }
   } catch (error) {
-    // Never break installation if bootstrap fails during postinstall.
     const message = error && error.message ? error.message : String(error);
-    console.warn(`[repo-hc] postinstall bootstrap skipped: ${message}`);
+    console.warn(`[repo-hc] VS Code settings update skipped: ${message}`);
   }
 }
 
@@ -99,12 +80,7 @@ async function main() {
   }
 
   if (command === "init") {
-    runInitCommand(args);
-    return;
-  }
-
-  if (command === "install") {
-    await runInstallCommand();
+    await runInitCommand(args);
     return;
   }
 

--- a/docs/housekeeping/README.md
+++ b/docs/housekeeping/README.md
@@ -6,10 +6,11 @@ Core install behavior:
 
 ```bash
 pnpm add repo-hc
+pnpm exec repo-hc init
 ```
 
-This bootstraps `.agents/`, `docs/`, and `AGENTS.md` into the project root.
-In interactive installs, users are prompted to optionally add VS Code `files.exclude` entries for common agent files.
+`repo-hc init` bootstraps `.agents/`, `docs/`, and `AGENTS.md` into the project root.
+When `repo-hc init` runs interactively, users are prompted to optionally add VS Code `files.exclude` entries for common agent files.
 For `.agents/rules`, `.agents/learnings`, `.agents/plans`, and `.agents/prompts`, bootstrap transfers only each folder's `examples/` content.
 
 ## Documents

--- a/docs/housekeeping/developers.md
+++ b/docs/housekeeping/developers.md
@@ -28,22 +28,21 @@ Current status: architecture and documentation baseline, package runtime not pub
 
 ## Package Bootstrap Runtime
 
-`repo-hc` ships with a CLI and an install hook:
+`repo-hc` ships with a CLI and helper modules:
 
-- `bin/repo-hc.cjs`: CLI entrypoint (`init`, `install`)
+- `bin/repo-hc.cjs`: CLI entrypoint (`init`)
 - `lib/bootstrap.cjs`: non-destructive copy logic
 - `lib/vscode-settings.cjs`: VS Code `files.exclude` merge + prompt logic
-- `package.json` `postinstall`: runs `repo-hc install`
 
-Default install behavior copies these package assets to consumer root:
+`repo-hc init` copies these package assets to consumer root:
 
 - `.agents/`
 - `docs/`
 - `AGENTS.md`
 
-`install` is intentionally non-destructive and does not overwrite existing files.
+`init` is intentionally non-destructive and does not overwrite existing files.
 Use `repo-hc init --force` for explicit overwrite.
-When running in an interactive terminal, `install` prompts users to optionally hide `.agents` and `AGENTS.md` in VS Code by updating `.vscode/settings.json` without overwriting existing excludes. Existing VS Code JSON-with-comments settings are supported.
+When running in an interactive terminal, `init` prompts users to optionally hide `.agents` and `AGENTS.md` in VS Code by updating `.vscode/settings.json` without overwriting existing excludes. Existing VS Code JSON-with-comments settings are supported.
 Bootstrap filters `.agents` so that only `examples/` content is copied for `rules`, `learnings`, `plans`, and `prompts`; non-example files in those areas remain package-repository internal.
 
 ## Security Requirements

--- a/docs/housekeeping/users.md
+++ b/docs/housekeeping/users.md
@@ -26,11 +26,18 @@ pnpm add repo-hc
 
 During installation, `repo-hc` bootstraps the following assets into the project root:
 
+```bash
+pnpm add repo-hc
+pnpm exec repo-hc init
+```
+
+After running `repo-hc init`, these assets are bootstrapped into the project root:
+
 - `.agents/`
 - `docs/`
 - `AGENTS.md` (canonical)
 
-If installation runs in an interactive terminal, `repo-hc` asks whether these common agent files and directories should be hidden in VS Code Explorer.  
+If `repo-hc init` runs in an interactive terminal, it asks whether these common agent files and directories should be hidden in VS Code Explorer.  
 If accepted, `.vscode/settings.json` is created or merged with `files.exclude` entries for `.agents` and `AGENTS.md`.
 For `.agents/rules`, `.agents/learnings`, `.agents/plans`, and `.agents/prompts`, only `examples/` content is transferred to your project.
 

--- a/docs/mermaid/housekeeping-architecture.md
+++ b/docs/mermaid/housekeeping-architecture.md
@@ -38,9 +38,9 @@ flowchart TD
 
 ```mermaid
 flowchart LR
-  ADD["pnpm add repo-hc"] --> POSTINSTALL["postinstall: repo-hc install"]
-  POSTINSTALL --> COPY["Bootstrap Copy"]
-  POSTINSTALL --> PROMPT["Prompt: Hide agent files in VS Code?"]
+  ADD["pnpm add repo-hc"] --> INIT["pnpm exec repo-hc init"]
+  INIT --> COPY["Bootstrap Copy"]
+  INIT --> PROMPT["Prompt: Hide agent files in VS Code?"]
   COPY --> AGENTS[".agents/"]
   COPY --> EXAMPLES["Only examples in rules/learnings/plans/prompts"]
   COPY --> DOCS["docs/"]

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "CONTRIBUTING.md"
   ],
   "scripts": {
-    "postinstall": "node ./bin/repo-hc.cjs install",
     "test": "node --test ./test/*.test.cjs"
   },
   "engines": {


### PR DESCRIPTION
### Summary
This PR changes the bootstrap UX from automatic `postinstall` execution to an explicit `init` command flow.

New expected usage:

```bash
pnpm add repo-hc
pnpm exec repo-hc init
```

## Why
`postinstall` scripts are often blocked by package-manager security defaults (for example pnpm build-script approval), which creates friction during installation.  
An explicit `init` step is clearer and more predictable for end users.

## What changed
- Removed `postinstall` script from `package.json`.
- Removed `install` command from CLI.
- Kept `init` as the bootstrap entrypoint.
- Kept VS Code hide prompt and moved it to run during `init` (interactive terminals).
- Updated docs (`README`, housekeeping docs, mermaid flow) to init-first usage.
- Synced `.agents` docs (plan, learning, prompt, index).

## Behavior
- Bootstrap remains non-destructive by default.
- `repo-hc init --force` still overwrites intentionally.
- Examples-only transfer behavior under `.agents` remains unchanged.

## Validation
- Ran: `node --test ./test/*.test.cjs`
- Result: `9 passed, 0 failed`
